### PR TITLE
Support nested workspace config

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -10,8 +10,8 @@ exports.resolvePatterns = (cwd) => {
     try {
       const pkg = JSON.parse(fs.readFileSync(pkgFile, { encoding: 'utf8' }))
       if (pkg.workspaces) {
-        return pkg.workspaces
-      }
+        return pkg.workspaces.packages || pkg.workspaces
+      } else if ()
     } catch (e) {
       // Error
     }

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -11,7 +11,7 @@ exports.resolvePatterns = (cwd) => {
       const pkg = JSON.parse(fs.readFileSync(pkgFile, { encoding: 'utf8' }))
       if (pkg.workspaces) {
         return pkg.workspaces.packages || pkg.workspaces
-      } else if ()
+      } 
     } catch (e) {
       // Error
     }


### PR DESCRIPTION
Hey!
I've made a simple update to patterns recognition. Currently the tool only recognises workspaces properly if they are defined as array: 

```"workspaces": [...]```

If someone is trying to use `nohoist` option the tool cannot recognise the pattern correctly as the config changes to:

```"workpsaces": { "packages": [...], "nohoist": [...] }```